### PR TITLE
Add persistent auth and contact-based chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+data.sqlite

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,6 +19,11 @@ server {
         proxy_set_header Host $host;
     }
 
+    location /api/ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+    }
+
     location / {
         root /var/www/sealmax/public;
         index index.html;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "better-sqlite3": "^9.4.0",
         "cookie-parser": "^1.4.7",
         "express": "^5.1.0",
+        "express-session": "^1.18.0",
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
@@ -1684,6 +1687,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
@@ -1691,6 +1714,43 @@
       "license": "MIT",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -1777,6 +1837,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -1891,6 +1975,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.3.0",
@@ -2169,6 +2259,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -2182,6 +2287,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deepmerge": {
@@ -2211,6 +2325,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -2295,6 +2418,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -2564,6 +2696,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "30.1.2",
       "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
@@ -2624,6 +2765,46 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/express/node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -2656,6 +2837,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -2794,6 +2981,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2904,6 +3097,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -3049,6 +3248,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3095,6 +3314,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -4113,6 +4338,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4129,6 +4366,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4139,10 +4385,22 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -4175,6 +4433,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-int64": {
@@ -4243,6 +4525,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4468,6 +4759,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.0.5",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
@@ -4509,6 +4826,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -4541,6 +4868,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4565,12 +4901,50 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -4808,6 +5182,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5035,6 +5454,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -5275,6 +5703,34 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5373,6 +5829,18 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5408,6 +5876,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undici-types": {
@@ -5490,6 +5970,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "better-sqlite3": "^9.4.0",
     "cookie-parser": "^1.4.7",
     "express": "^5.1.0",
+    "express-session": "^1.18.0",
     "socket.io": "^4.8.1"
   },
   "devDependencies": {

--- a/public/client.js
+++ b/public/client.js
@@ -1,120 +1,174 @@
-function getCookie(name) {
-  const value = document.cookie.split('; ').find(row => row.startsWith(name + '='));
-  return value ? decodeURIComponent(value.split('=')[1]) : null;
+async function api(path, method = 'GET', body) {
+  const opts = { method, headers: { 'Content-Type': 'application/json' } };
+  if (body) opts.body = JSON.stringify(body);
+  const res = await fetch(path, opts);
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
 }
 
-function setCookie(name, value, days = 365) {
-  const expires = new Date(Date.now() + days * 864e5).toUTCString();
-  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
-}
-
-const usernameDisplay = document.getElementById('usernameDisplay');
-const changeNameBtn = document.getElementById('changeNameBtn');
-const nameModal = document.getElementById('nameModal');
-const nameInput = document.getElementById('nameInput');
-const saveName = document.getElementById('saveName');
-
-let username = getCookie('username') || '';
-
-function updateUsername(newName) {
-  username = newName || 'Anonymous';
-  setCookie('username', username);
-  usernameDisplay.textContent = username;
-}
-
-if (!username) {
-  nameModal.style.display = 'flex';
-} else {
-  usernameDisplay.textContent = username;
-}
-
-changeNameBtn.addEventListener('click', () => {
-  nameInput.value = username;
-  nameModal.style.display = 'flex';
-});
-
-saveName.addEventListener('click', () => {
-  updateUsername(nameInput.value.trim());
-  nameModal.style.display = 'none';
-});
-
-function loadMessages() {
-  const data = localStorage.getItem('messages');
-  return data ? JSON.parse(data) : [];
-}
-
-function saveMessages(msgs) {
-  localStorage.setItem('messages', JSON.stringify(msgs));
-}
-
-let lastReadId = parseInt(localStorage.getItem('lastReadId') || '0', 10);
-const messages = loadMessages();
-const ul = document.getElementById('messages');
-
-function renderMessage(msg, markUnread) {
-  const item = document.createElement('li');
-  item.textContent = `${msg.user}: ${msg.text}`;
-  if (markUnread && msg.id > lastReadId) {
-    item.classList.add('unread');
-  }
-  ul.appendChild(item);
-}
-
-messages.forEach(msg => {
-  renderMessage(msg, msg.id > lastReadId);
-});
-if (messages.length) {
-  lastReadId = messages[messages.length - 1].id;
-}
-
-const socket = io();
-
-socket.on('chat history', history => {
-  history.forEach(msg => {
-    if (!messages.find(m => m.id === msg.id)) {
-      renderMessage(msg, msg.id > lastReadId);
-      messages.push(msg);
-    }
-  });
-  if (messages.length) {
-    lastReadId = messages[messages.length - 1].id;
-  }
-  saveMessages(messages);
-});
-
-socket.on('chat message', msg => {
-  const hidden = document.hidden;
-  renderMessage(msg, hidden);
-  messages.push(msg);
-  saveMessages(messages);
-  if (!hidden) {
-    lastReadId = msg.id;
-  }
-});
-
+const authBox = document.getElementById('auth');
+const registerBox = document.getElementById('register');
+const loginUser = document.getElementById('loginUser');
+const loginPass = document.getElementById('loginPass');
+const loginBtn = document.getElementById('loginBtn');
+const showRegister = document.getElementById('showRegister');
+const regUser = document.getElementById('regUser');
+const regPass = document.getElementById('regPass');
+const regBtn = document.getElementById('regBtn');
+const showLogin = document.getElementById('showLogin');
+const app = document.getElementById('app');
+const contactsUl = document.getElementById('contacts');
+const contactSearch = document.getElementById('contactSearch');
+const messagesUl = document.getElementById('messages');
 const form = document.getElementById('form');
 const input = document.getElementById('input');
+const chatWith = document.getElementById('chatWith');
+const logoutBtn = document.getElementById('logoutBtn');
+
+let socket;
+let me = null;
+let activeId = 0;
+const contacts = new Map();
+
+function renderContacts() {
+  contactsUl.innerHTML = '';
+  const general = { id: 0, username: 'General' };
+  [general, ...contacts.values()].forEach(u => {
+    const li = document.createElement('li');
+    li.textContent = u.username + (u.id ? ` (@${u.id})` : '');
+    li.dataset.id = u.id;
+    if (u.id === activeId) li.classList.add('active');
+    li.onclick = () => selectContact(u.id);
+    contactsUl.appendChild(li);
+  });
+}
+
+async function loadContacts() {
+  const list = await api('/api/users');
+  list.forEach(u => contacts.set(u.id, u));
+  renderContacts();
+}
+
+async function loadMessages(id) {
+  messagesUl.innerHTML = '';
+  const msgs = await api(`/api/messages/${id}`);
+  msgs.forEach(renderMessage);
+  messagesUl.scrollTop = messagesUl.scrollHeight;
+}
+
+function renderMessage(m) {
+  const li = document.createElement('li');
+  const sender = m.senderId === me.id ? 'Me' : contacts.get(m.senderId)?.username || `@${m.senderId}`;
+  li.textContent = `${sender}: ${m.text}`;
+  messagesUl.appendChild(li);
+}
+
+function selectContact(id) {
+  activeId = id;
+  chatWith.textContent = id === 0 ? 'General' : contacts.get(id)?.username || `@${id}`;
+  renderContacts();
+  loadMessages(id);
+}
+
+loginBtn.onclick = async () => {
+  try {
+    me = await api('/api/login', 'POST', { username: loginUser.value, password: loginPass.value });
+    authBox.style.display = 'none';
+    app.style.display = 'flex';
+    await loadContacts();
+    initSocket();
+    selectContact(0);
+  } catch (e) {
+    alert('Login failed');
+  }
+};
+
+showRegister.onclick = () => {
+  authBox.style.display = 'none';
+  registerBox.style.display = 'flex';
+};
+
+showLogin.onclick = () => {
+  registerBox.style.display = 'none';
+  authBox.style.display = 'flex';
+};
+
+regBtn.onclick = async () => {
+  try {
+    await api('/api/register', 'POST', { username: regUser.value, password: regPass.value });
+    registerBox.style.display = 'none';
+    authBox.style.display = 'flex';
+  } catch (e) {
+    alert('Registration failed');
+  }
+};
+
+async function init() {
+  try {
+    const user = await api('/api/me');
+    if (user.id) {
+      me = user;
+      authBox.style.display = 'none';
+      app.style.display = 'flex';
+      await loadContacts();
+      initSocket();
+      selectContact(0);
+    }
+  } catch {}
+}
+
+function initSocket() {
+  socket = io();
+  socket.on('chat history', msgs => {
+    if (activeId === 0) {
+      messagesUl.innerHTML = '';
+      msgs.forEach(renderMessage);
+      messagesUl.scrollTop = messagesUl.scrollHeight;
+    }
+  });
+  socket.on('chat message', msg => {
+    const relevant = msg.recipientId === 0 && activeId === 0 ||
+      (msg.senderId === activeId && msg.recipientId === me.id) ||
+      (msg.senderId === me.id && msg.recipientId === activeId);
+    if (relevant) {
+      renderMessage(msg);
+      messagesUl.scrollTop = messagesUl.scrollHeight;
+    }
+    if (!contacts.has(msg.senderId) && msg.senderId !== me.id) {
+      // load new contact
+      api(`/api/users/${msg.senderId}`).then(u => {
+        contacts.set(u.id, u);
+        renderContacts();
+      }).catch(() => {});
+    }
+  });
+}
 
 form.addEventListener('submit', e => {
   e.preventDefault();
-  if (input.value) {
-    const msg = { id: Date.now(), user: username || 'Anonymous', text: input.value };
-    socket.emit('chat message', msg);
-    input.value = '';
+  const text = input.value.trim();
+  if (!text) return;
+  socket.emit('chat message', { recipientId: activeId, text });
+  input.value = '';
+});
+
+contactSearch.addEventListener('keydown', async e => {
+  if (e.key === 'Enter') {
+    const id = parseInt(contactSearch.value.slice(1), 10);
+    contactSearch.value = '';
+    if (id && !contacts.has(id)) {
+      try {
+        const u = await api(`/api/users/${id}`);
+        contacts.set(u.id, u);
+        renderContacts();
+      } catch {}
+    }
   }
 });
 
-document.addEventListener('visibilitychange', () => {
-  if (!document.hidden) {
-    lastReadId = messages.length ? messages[messages.length - 1].id : lastReadId;
-    setTimeout(() => {
-      document.querySelectorAll('.unread').forEach(item => item.classList.remove('unread'));
-    }, 1000);
-  }
-});
+logoutBtn.onclick = async () => {
+  await api('/api/logout', 'POST');
+  location.reload();
+};
 
-window.addEventListener('beforeunload', () => {
-  if (messages.length) {
-    localStorage.setItem('lastReadId', messages[messages.length - 1].id);
-  }
-});
+init();

--- a/public/index.html
+++ b/public/index.html
@@ -6,43 +6,87 @@
   <script src="/socket.io/socket.io.js"></script>
   <script src="client.js" defer></script>
   <style>
-    body {
-      font-family: Arial, sans-serif;
+    html, body {
+      height: 100%;
       margin: 0;
-      height: 100vh;
-      display: flex;
-      flex-direction: column;
+      font-family: Arial, sans-serif;
       background: #f4f4f9;
     }
-    header {
+    body {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    #auth, #register {
+      margin: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      width: 300px;
+      background: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    #app {
+      flex: 1;
+      display: none;
+      flex-direction: row;
+      height: 100%;
+    }
+    #sidebar {
+      width: 200px;
+      background: #fff;
+      border-right: 1px solid #ddd;
+      display: flex;
+      flex-direction: column;
+    }
+    #contactSearch {
+      padding: 10px;
+      border: none;
+      border-bottom: 1px solid #ddd;
+    }
+    #contacts {
+      flex: 1;
+      overflow-y: auto;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    #contacts li {
+      padding: 10px;
+      cursor: pointer;
+      border-bottom: 1px solid #eee;
+    }
+    #contacts li.active {
+      background: #e0f7fa;
+    }
+    #chatArea {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+    }
+    #chatHeader {
+      padding: 10px;
       background: #4a90e2;
       color: #fff;
-      padding: 10px;
       display: flex;
       justify-content: space-between;
       align-items: center;
     }
-    #chat {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-    }
     #messages {
+      flex: 1;
+      overflow-y: auto;
       list-style: none;
       margin: 0;
       padding: 10px;
-      flex: 1;
-      overflow-y: auto;
     }
     #messages li {
       background: #fff;
       margin-bottom: 10px;
       padding: 8px 12px;
       border-radius: 4px;
-    }
-    #messages li.unread {
-      font-weight: bold;
-      background: #e0f7fa;
     }
     #form {
       display: flex;
@@ -64,45 +108,35 @@
       border-radius: 4px;
       cursor: pointer;
     }
-    #nameModal {
-      display: none;
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0, 0, 0, 0.5);
-      justify-content: center;
-      align-items: center;
-    }
-    #nameModal .content {
-      background: #fff;
-      padding: 20px;
-      border-radius: 8px;
-      display: flex;
-      gap: 10px;
-    }
   </style>
 </head>
 <body>
-  <header>
-    <span>Sealmax Messenger</span>
-    <div>
-      <span id="usernameDisplay"></span>
-      <button id="changeNameBtn">Change name</button>
-    </div>
-  </header>
-  <div id="chat">
-    <ul id="messages"></ul>
-    <form id="form" autocomplete="off">
-      <input id="input" placeholder="Type a message" />
-      <button>Send</button>
-    </form>
+  <div id="auth">
+    <h2>Sign in</h2>
+    <input id="loginUser" placeholder="Username" />
+    <input id="loginPass" type="password" placeholder="Password" />
+    <button id="loginBtn">Login</button>
+    <button id="showRegister">Register</button>
   </div>
-  <div id="nameModal">
-    <div class="content">
-      <input id="nameInput" placeholder="Enter your name" />
-      <button id="saveName">Save</button>
+  <div id="register" style="display:none;">
+    <h2>Register</h2>
+    <input id="regUser" placeholder="Username" />
+    <input id="regPass" type="password" placeholder="Password" />
+    <button id="regBtn">Create account</button>
+    <button id="showLogin">Back</button>
+  </div>
+  <div id="app">
+    <div id="sidebar">
+      <input id="contactSearch" placeholder="@id" />
+      <ul id="contacts"></ul>
+    </div>
+    <div id="chatArea">
+      <div id="chatHeader"><span id="chatWith">General</span><button id="logoutBtn">Logout</button></div>
+      <ul id="messages"></ul>
+      <form id="form" autocomplete="off">
+        <input id="input" placeholder="Type a message" />
+        <button>Send</button>
+      </form>
     </div>
   </div>
 </body>

--- a/server.js
+++ b/server.js
@@ -2,21 +2,138 @@ const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');
 const cookieParser = require('cookie-parser');
+const session = require('express-session');
+const bcrypt = require('bcryptjs');
+const Database = require('better-sqlite3');
+
+const db = new Database('data.sqlite');
+db.prepare(`CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE,
+  password TEXT
+)`).run();
+db.prepare(`CREATE TABLE IF NOT EXISTS messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  senderId INTEGER,
+  recipientId INTEGER,
+  text TEXT,
+  timestamp INTEGER
+)`).run();
 
 const app = express();
 app.use(cookieParser());
+app.use(express.json());
+
+const sessionMiddleware = session({
+  secret: process.env.SESSION_SECRET || 'sealmax',
+  resave: false,
+  saveUninitialized: false
+});
+app.use(sessionMiddleware);
 app.use(express.static('public'));
+
+function requireAuth(req, res, next) {
+  if (!req.session.userId) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  next();
+}
+
+app.post('/api/register', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'missing fields' });
+  }
+  try {
+    const hash = bcrypt.hashSync(password, 10);
+    const info = db.prepare('INSERT INTO users (username, password) VALUES (?, ?)').run(username, hash);
+    res.json({ id: info.lastInsertRowid, username });
+  } catch (e) {
+    res.status(400).json({ error: 'user exists' });
+  }
+});
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = db.prepare('SELECT * FROM users WHERE username = ?').get(username);
+  if (!user || !bcrypt.compareSync(password, user.password)) {
+    return res.status(401).json({ error: 'invalid credentials' });
+  }
+  req.session.userId = user.id;
+  res.json({ id: user.id, username: user.username });
+});
+
+app.post('/api/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.json({ ok: true });
+  });
+});
+
+app.get('/api/me', (req, res) => {
+  if (!req.session.userId) {
+    return res.json({ id: null });
+  }
+  const user = db.prepare('SELECT id, username FROM users WHERE id = ?').get(req.session.userId);
+  res.json(user);
+});
+
+app.get('/api/users', requireAuth, (req, res) => {
+  const users = db.prepare('SELECT id, username FROM users WHERE id != ?').all(req.session.userId);
+  res.json(users);
+});
+
+app.get('/api/users/:id', requireAuth, (req, res) => {
+  const user = db.prepare('SELECT id, username FROM users WHERE id = ?').get(req.params.id);
+  if (!user) {
+    return res.status(404).json({ error: 'not found' });
+  }
+  res.json(user);
+});
+
+app.get('/api/messages/:id', requireAuth, (req, res) => {
+  const cid = parseInt(req.params.id, 10);
+  let rows;
+  if (cid === 0) {
+    rows = db.prepare('SELECT * FROM messages WHERE recipientId = 0 ORDER BY id').all();
+  } else {
+    rows = db.prepare(`SELECT * FROM messages WHERE (senderId = ? AND recipientId = ?) OR (senderId = ? AND recipientId = ?) ORDER BY id`).all(req.session.userId, cid, cid, req.session.userId);
+  }
+  res.json(rows);
+});
 
 const server = http.createServer(app);
 const io = new Server(server);
 
-const history = [];
+io.use((socket, next) => {
+  sessionMiddleware(socket.request, {}, next);
+});
 
-io.on('connection', (socket) => {
+io.on('connection', socket => {
+  const userId = socket.request.session.userId;
+  if (!userId) {
+    return socket.disconnect();
+  }
+  socket.join(`user_${userId}`);
+  const history = db.prepare('SELECT * FROM messages WHERE recipientId = 0 ORDER BY id').all();
   socket.emit('chat history', history);
-  socket.on('chat message', (data) => {
-    history.push(data);
-    io.emit('chat message', data);
+  socket.on('chat message', data => {
+    if (!data || typeof data.text !== 'string') {
+      return;
+    }
+    const recipientId = parseInt(data.recipientId, 10) || 0;
+    const text = data.text.trim();
+    if (!text) {
+      return;
+    }
+    const timestamp = Date.now();
+    const info = db.prepare('INSERT INTO messages (senderId, recipientId, text, timestamp) VALUES (?, ?, ?, ?)').run(userId, recipientId, text, timestamp);
+    const msg = { id: info.lastInsertRowid, senderId: userId, recipientId, text, timestamp };
+    if (recipientId === 0) {
+      io.emit('chat message', msg);
+    } else {
+      io.to(`user_${recipientId}`).emit('chat message', msg);
+      socket.emit('chat message', msg);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Persist users and messages in SQLite with registration and login
- Add contact sidebar with search and scoped conversations
- Improve chat layout with fixed-height scroll area
- Proxy /api/* requests via Nginx so registration and other endpoints resolve

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57979e93c8325b16576d1d6aefd8b