### PR TITLE
Add custom IDs and chat UI improvements

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -22,9 +22,10 @@ test('register, login and chat', done => {
   const agent = request.agent(httpServer);
   agent
     .post('/api/register')
-    .send({ username: 'u1', password: 'p1' })
+    .send({ username: 'u1', password: 'p1', customId: 'alpha1' })
     .then(() => agent.post('/api/login').send({ username: 'u1', password: 'p1' }))
     .then(res => {
+      expect(res.body.customId).toBe('alpha1');
       const cookie = res.headers['set-cookie'][0];
       const client = io('http://localhost:3000', { extraHeaders: { Cookie: cookie } });
       client.on('chat history', () => {
@@ -34,6 +35,53 @@ test('register, login and chat', done => {
         expect(msg.text).toBe('hello');
         client.close();
         done();
+      });
+    });
+});
+
+test('rejects invalid custom id', async () => {
+  const res = await request(httpServer)
+    .post('/api/register')
+    .send({ username: 'u2', password: 'p2', customId: '1bad' });
+  expect(res.statusCode).toBe(400);
+});
+
+test('fetch user by custom id', async () => {
+  const agent = request.agent(httpServer);
+  await agent.post('/api/register').send({ username: 'u3', password: 'p3', customId: 'alpha3' });
+  await agent.post('/api/login').send({ username: 'u3', password: 'p3' });
+  const res = await agent.get('/api/custom/alpha3');
+  expect(res.body.username).toBe('u3');
+});
+
+test('contacts list only shows chatted users', done => {
+  const agent1 = request.agent(httpServer);
+  const agent2 = request.agent(httpServer);
+  Promise.all([
+    agent1.post('/api/register').send({ username: 'u4', password: 'p4', customId: 'alpha4' }),
+    agent2.post('/api/register').send({ username: 'u5', password: 'p5', customId: 'alpha5' })
+  ])
+    .then(() => Promise.all([
+      agent1.post('/api/login').send({ username: 'u4', password: 'p4' }),
+      agent2.post('/api/login').send({ username: 'u5', password: 'p5' })
+    ]))
+    .then(([res1, res2]) => {
+      const id2 = res2.body.id;
+      const cookie1 = res1.headers['set-cookie'][0];
+      const cookie2 = res2.headers['set-cookie'][0];
+      const client1 = io('http://localhost:3000', { extraHeaders: { Cookie: cookie1 } });
+      const client2 = io('http://localhost:3000', { extraHeaders: { Cookie: cookie2 } });
+      client2.on('chat message', async () => {
+        client1.close();
+        client2.close();
+        const c1 = await agent1.get('/api/contacts');
+        const c2 = await agent2.get('/api/contacts');
+        expect(c1.body.some(u => u.username === 'u5')).toBe(true);
+        expect(c2.body.some(u => u.username === 'u4')).toBe(true);
+        done();
+      });
+      client1.on('chat history', () => {
+        client1.emit('chat message', { recipientId: id2, text: 'hi' });
       });
     });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
     }
     #sidebar {
       width: 200px;
-      background: #fff;
+      background: #fafafa;
       border-right: 1px solid #ddd;
       display: flex;
       flex-direction: column;
@@ -57,9 +57,19 @@
       padding: 10px;
       cursor: pointer;
       border-bottom: 1px solid #eee;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
     }
     #contacts li.active {
       background: #e0f7fa;
+    }
+    .badge {
+      background: red;
+      color: #fff;
+      border-radius: 50%;
+      padding: 2px 6px;
+      font-size: 12px;
     }
     #chatArea {
       flex: 1;
@@ -81,12 +91,23 @@
       list-style: none;
       margin: 0;
       padding: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
     }
     #messages li {
-      background: #fff;
-      margin-bottom: 10px;
+      max-width: 60%;
       padding: 8px 12px;
-      border-radius: 4px;
+      border-radius: 12px;
+      word-break: break-word;
+    }
+    #messages li.mine {
+      background: #dcf8c6;
+      align-self: flex-end;
+    }
+    #messages li.theirs {
+      background: #fff;
+      align-self: flex-start;
     }
     #form {
       display: flex;
@@ -121,6 +142,7 @@
   <div id="register" style="display:none;">
     <h2>Register</h2>
     <input id="regUser" placeholder="Username" />
+    <input id="regCustom" placeholder="Custom ID" />
     <input id="regPass" type="password" placeholder="Password" />
     <button id="regBtn">Create account</button>
     <button id="showLogin">Back</button>


### PR DESCRIPTION
## Summary
- allow users to register with custom IDs and search contacts by them
- show unread chat badges and align message bubbles by sender
- load only chatted users in sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57da2d8188325a0623204f93f5a0c