### PR TITLE
Add logo across auth and chat views

### DIFF
--- a/__tests__/frontend.test.js
+++ b/__tests__/frontend.test.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+const path = require('path');
+
+test('index includes logo and favicon', () => {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'public', 'index.html'), 'utf8');
+  expect(html).toMatch(/<link[^>]*rel=["']icon["'][^>]*href=["']logo\.png["']/);
+  const images = html.match(/<img[^>]*src=["']logo\.png["']/g) || [];
+  expect(images.length).toBeGreaterThanOrEqual(3);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <link rel="icon" href="logo.png">
   <link rel="stylesheet" href="style.css">
   <title>Sealmax Messenger</title>
   <script src="/socket.io/socket.io.js"></script>
@@ -9,6 +10,7 @@
 </head>
 <body>
   <div id="auth">
+    <img src="logo.png" alt="Sealmax logo" class="logo">
     <h2>Sign in</h2>
     <input id="loginUser" placeholder="Username" />
     <input id="loginPass" type="password" placeholder="Password" />
@@ -17,6 +19,7 @@
     <button id="showRegister">Register</button>
   </div>
   <div id="register" style="display:none;">
+    <img src="logo.png" alt="Sealmax logo" class="logo">
     <h2>Register</h2>
     <input id="regUser" placeholder="Username" />
     <input id="regCustom" placeholder="Custom ID" />
@@ -31,7 +34,13 @@
       <ul id="contacts"></ul>
     </div>
     <div id="chatArea">
-      <div id="chatHeader"><span id="chatWith">General</span><button id="logoutBtn">Logout</button></div>
+      <div id="chatHeader">
+        <div id="chatTitle">
+          <img src="logo.png" alt="Sealmax logo" class="logo small">
+          <span id="chatWith">General</span>
+        </div>
+        <button id="logoutBtn">Logout</button>
+      </div>
       <ul id="messages"></ul>
       <form id="form" autocomplete="off">
         <input id="input" placeholder="Type a message" />

--- a/public/style.css
+++ b/public/style.css
@@ -20,6 +20,17 @@ body {
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
+
+.logo {
+  width: 100px;
+  margin: 0 auto 10px;
+  display: block;
+}
+
+.logo.small {
+  width: 40px;
+  margin: 0;
+}
 #app {
   flex: 1;
   display: none;
@@ -76,6 +87,12 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+#chatTitle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 #messages {
   flex: 1;


### PR DESCRIPTION
## Summary
- show logo on login, registration, and chat pages
- add favicon and styles for logo
- test that logo and favicon are present in the HTML

## Testing
- `npm test` *(fails: Could not locate the bindings file for better-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68b6909b35488325bed3f51c3539221e