### PR TITLE
Remove custom ID and add theme switcher

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,11 +48,6 @@
     </div>
 
     <div class="field">
-      <label for="regCustom">Кастомный ID</label>
-      <input id="regCustom" placeholder="@custom_id" inputmode="latin" pattern="^[a-z0-9_]{3,20}$" title="3–20 символов, латиница, цифры и подчёркивание" />
-    </div>
-
-    <div class="field">
       <label for="regPass">Пароль</label>
       <input id="regPass" type="password" placeholder="минимум 8 символов" autocomplete="new-password" minlength="8" required />
     </div>
@@ -69,7 +64,7 @@
   <div id="app">
     <aside id="sidebar" aria-label="Контакты">
       <div class="search">
-        <input id="contactSearch" placeholder="@id" aria-label="Поиск по кастомному ID (@id)" />
+        <input id="contactSearch" placeholder="username" aria-label="Поиск по логину" />
       </div>
       <ul id="contacts" role="listbox" aria-label="Список контактов"></ul>
     </aside>
@@ -80,7 +75,10 @@
           <img src="logo.png" alt="Sealmax logo" class="logo small" />
           <span id="chatWith">General</span>
         </div>
-        <button id="logoutBtn" class="btn subtle">Выйти</button>
+        <div class="header-buttons">
+          <button id="themeBtn" class="btn subtle">Тема</button>
+          <button id="logoutBtn" class="btn subtle">Выйти</button>
+        </div>
       </header>
 
       <ul id="messages" aria-label="Сообщения"></ul>

--- a/public/style.css
+++ b/public/style.css
@@ -19,6 +19,17 @@
   --shadow-2: 0 1px 3px rgba(60,64,67,.2), 0 4px 8px rgba(60,64,67,.15);
 }
 
+:root.dark{
+  --bg:#121212;
+  --surface:#1e1f21;
+  --text:#e8eaed;
+  --muted:#bdc1c6;
+  --border:#2a2b2f;
+
+  --shadow-1: 0 1px 2px rgba(0,0,0,.6), 0 1px 3px 1px rgba(0,0,0,.5);
+  --shadow-2: 0 2px 6px rgba(0,0,0,.6), 0 6px 12px rgba(0,0,0,.5);
+}
+
 @media (prefers-color-scheme: dark){
   :root{
     --bg:#121212;
@@ -212,6 +223,7 @@ input:disabled{ opacity: .6; }
   border-bottom: 1px solid var(--border);
   position: sticky; top: 0; z-index: 10;
 }
+#chatHeader .header-buttons{ display:flex; gap:8px; }
 #chatTitle{
   display: flex; align-items: center; gap: 10px;
   font-weight: 500;


### PR DESCRIPTION
## Summary
- remove custom ID support and switch to username-based lookup
- add light/dark theme toggle with persistent preference
- update tests for username-only workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b698725dec83259d92e421b17f58cd